### PR TITLE
Fix conda installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install freesasa
 Or, alternatively, by using conda
 
 ```sh
-conda install freesasa
+conda install -c conda-forge freesasa
 ```
 
 Developers can clone the library, and then build the module by the following


### PR DESCRIPTION
Sorry, I just realized this wasn't correct. `conda-forge` is the default channel on `mamba`, but not on `conda`, so it needs the channel specification.