### PR TITLE
Modify conda-forge's `freesasa` to use `freesasa-python`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install freesasa
 Or, alternatively, by using conda
 
 ```sh
-conda install -c conda-forge freesasa
+conda install -c conda-forge freesasa-python
 ```
 
 Developers can clone the library, and then build the module by the following


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` file to reflect the correct package name for installation via conda.

Currently, the freesasa Python module can be installed using either `freesasa` or `freesasa-python` on conda-forge, but since the conventional `freesasa` may be confused with the C implementation `freesasa-c`, I think it is preferable to use `freesasa-python`.